### PR TITLE
APP->engine->getSampleRate() should not be used anymore. SR change to…

### DIFF
--- a/src/ProtoFaust.cpp
+++ b/src/ProtoFaust.cpp
@@ -178,20 +178,17 @@ void ProtoFaust::onAdd()
       attachFaustParameter( widget );
    }
 
-   FaustDSP.init(
-      APP->engine->getSampleRate() );
+   // Init DSP with default SR
+   FaustDSP.init(44100);
 }
 
 
-void ProtoFaust::onSampleRateChange()
+void ProtoFaust::process( const ProcessArgs& args )
 {
-   FaustDSP.instanceConstants(
-      APP->engine->getSampleRate() );
-}
-
-
-void ProtoFaust::process( const ProcessArgs& /* args (unused) */ )
-{
+   // Possibly update SR
+   if (args.sampleRate != FaustDSP.getSampleRate()) {
+       FaustDSP.init(args.sampleRate);
+   }
    std::vector<FAUSTFLOAT> temporaryInputs( numberOfChannels );
    std::vector<FAUSTFLOAT> temporaryOutputs( numberOfChannels );
 

--- a/src/ProtoFaust.hpp
+++ b/src/ProtoFaust.hpp
@@ -129,8 +129,7 @@ public:
    ProtoFaust();
 
    void onAdd() override;
-   void onSampleRateChange() override;
-
+ 
    void process( const ProcessArgs& args ) override;
 
 private:


### PR DESCRIPTION
Discussion with @vortico (Andrew Belt) on VCV Discord channel: APP->engine->getSampleRate() should not be used anymore.